### PR TITLE
Improve error message for :phone_number validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in send_grid.gemspec
 gemspec

--- a/lib/has_validated_attributes.rb
+++ b/lib/has_validated_attributes.rb
@@ -12,7 +12,7 @@ module HasValidatedAttributes
         opts.each{|k,v| validation.merge!(:length => {k.to_s.split("_").first.to_sym => v});options.delete(k)} if opts.present?
         ### extra options ###
         validation.merge!(options) if options.present?
-        
+
         format.merge(validation)
       end
     end


### PR DESCRIPTION
Include the fact that the number is not allowed to be all 0s. This shouldn't be a big deal for user-inputted data, but I just ran across it in one of the data conversions.
